### PR TITLE
Relax numpy and pint version selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "xmltodict==0.13.0",
-    "pint>=0.17,<0.24; python_version <= '3.9'",
-    "numpy<2.0.0; python_version <= '3.9'",
-    "pint>=0.24; python_version >= '3.10'",
-    "numpy>=1.21.2; python_version >= '3.10'"
+    "numpy>=1.21.2",
+    "pint>=0.17",
 ]
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Based on my discussions with @blueraft, there is a need to relax numpy and pint version to align with this MR: https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1918

@lukaspie I made the same changes as you did on pynxtools-xps. I hope these changes don't create issues with pynxtools.