### PR TITLE
Implement hypix detector reader for Rigaku

### DIFF
--- a/src/fairmat_readers_xrd/ikz.py
+++ b/src/fairmat_readers_xrd/ikz.py
@@ -230,6 +230,37 @@ class RASXfile(object):
 
         return output
 
+    def get_scan_hypix_data(self, logger: 'BoundLogger' = None):
+        """
+        Collects the HyPix3000 detector data, if available.
+
+        Returns:
+            Dict[str, Any]: contains information about the HyPix data
+        """
+        if not self.images:
+            return None
+
+        output = collections.defaultdict(list)
+
+        for image in self.images:
+            # get intensity and two_theta
+            output['intensity'].append(to_pint_quantity(image, None))
+
+        for axis in ['TwoTheta', 'Omega', 'Chi', 'Phi', 'X', 'Y']:
+            # get axis positions
+            if axis not in self.positions:
+                output[axis] = None
+                continue
+            if not isinstance(self.positions[axis], np.ndarray):
+                self.positions[axis] = np.array([self.positions[axis]])
+            for ax_data_per_scan in self.positions[axis]:
+                ax_data_per_scan = ax_data_per_scan.reshape(-1)
+                output[axis].append(
+                    to_pint_quantity(ax_data_per_scan, self.units.get(axis, 'deg'))
+                )
+
+        return output
+
     def get_scan_data(self, logger: 'BoundLogger' = None):
         """
         Collect intensity, two_theta, and axis positions. If units are not available for
@@ -242,6 +273,9 @@ class RASXfile(object):
             Dict[str, Any]: Each element contains a list of scan data as ureg.Quantity
                 arrays.
         """
+        if not self.data:
+            return None
+
         output = collections.defaultdict(list)
 
         scan_axis = None

--- a/src/fairmat_readers_xrd/ikz.py
+++ b/src/fairmat_readers_xrd/ikz.py
@@ -127,6 +127,14 @@ def parse_rasx_metadata(xml):
                 print('Warning: unknown axis attribute: %s' % key)
         axes[axis.attrib['Name']] = Axis(**attrib)
 
+    if measurement.find('ImageInformation'):
+        mdata['ImageInformation'] = dict(
+            [
+                (info[0].text, try_scalar(info[1].text))
+                for info in measurement.find('ImageInformation/DTHeader')
+            ]
+        )
+
     return mdata
 
 
@@ -174,17 +182,16 @@ class RASXfile(object):
 
                 with fh.open(metafile) as xml:
                     meta.append(parse_rasx_metadata(xml))
-                optics = meta[-1]['HardwareConfig']['optics']
-                if optics['Detector'] == 'HyPix3000(H)':
-                    det_shape = 385, 775
-                elif optics['Detector'] == 'HyPix3000(V)':
-                    det_shape = 775, 385
+                image_info = meta[-1]['ImageInformation']
+                det_shape_str = image_info.get('PXD_DETECTOR_DIMENSIONS')
+                if det_shape_str:
+                    det_shape = tuple(int(i) for i in det_shape_str.split())
                 else:
                     det_shape = (-1,)
                 with fh.open(imgpath) as f:
-                    imgarr = np.fromstring(f.read(), dtype=np.uint32)
-                    imgarr.resize(det_shape)
-                    imgdata.append(imgarr)
+                    imgarr = np.frombuffer(f.read(), dtype=np.uint32).copy()
+                    resized_imgarr = np.reshape(imgarr, det_shape)
+                    imgdata.append(resized_imgarr)
 
             if verbose:
                 print()

--- a/src/fairmat_readers_xrd/readers.py
+++ b/src/fairmat_readers_xrd/readers.py
@@ -220,10 +220,20 @@ def read_rigaku_rasx(file_path: str, logger: 'BoundLogger' = None) -> Dict[str, 
     reader = RASXfile(file_path, verbose=False)
     scan_info = reader.get_scan_info()
     scan_data = reader.get_scan_data(logger)
+    scan_hypix_data = reader.get_scan_hypix_data(logger)
     source = reader.get_source_info()
 
-    scan_type = detect_scan_type(scan_data)
-    modified_scan_data = modify_scan_data(scan_data, scan_type)
+    if scan_data and not scan_hypix_data:
+        scan_type = detect_scan_type(scan_data)
+        modified_scan_data = modify_scan_data(scan_data, scan_type)
+    elif scan_hypix_data and not scan_data:
+        scan_type = '2d_mode'
+        modified_scan_data = modify_scan_data(scan_hypix_data, scan_type)
+    else:
+        raise ValueError(
+            'Unable to determine scan type. Only one of `scan_data` or '
+            '`scan_hypix_data` should be present.'
+        )
 
     count_time = None
     scan_axis = None

--- a/src/fairmat_readers_xrd/readers.py
+++ b/src/fairmat_readers_xrd/readers.py
@@ -227,7 +227,7 @@ def read_rigaku_rasx(file_path: str, logger: 'BoundLogger' = None) -> Dict[str, 
         scan_type = detect_scan_type(scan_data)
         modified_scan_data = modify_scan_data(scan_data, scan_type)
     elif scan_hypix_data and not scan_data:
-        scan_type = '2d_mode'
+        scan_type = 'area_detector'
         modified_scan_data = modify_scan_data(scan_hypix_data, scan_type)
     else:
         raise ValueError(

--- a/src/fairmat_readers_xrd/utils.py
+++ b/src/fairmat_readers_xrd/utils.py
@@ -133,6 +133,12 @@ def modify_scan_data(scan_data: dict, scan_type: str):
     to a 1D array containing the first row. Similar to before, if the elements of this row
     are identical, it is reduced to a point vector of size 1.
 
+    If the scan type is `area_detector`, the `intensity` is of shape (i,x,y) with `x`
+    and `y` being the pixel dimensions of the detector and `i` being the number of
+    images. All other data undergoes same transformation as in `rsm`: Matrix of shape
+    (1,n) is converted to a 1D array of length `n` and if the elements of this row
+    are identical, it is reduced to a point vector of size 1.
+
     If the scan type is `multiline`, the data is converted into a list of 1D arrays.
     Currently not implemented.
 
@@ -146,10 +152,10 @@ def modify_scan_data(scan_data: dict, scan_type: str):
     """
     output = collections.defaultdict(lambda: None)
 
-    if scan_type not in ['line', 'rsm', 'multiline', '2d_mode']:
+    if scan_type not in ['line', 'rsm', 'multiline', 'area_detector']:
         raise ValueError(f'Invalid scan type: {scan_type}')
 
-    if scan_type in ['line', '2d_mode']:
+    if scan_type in ['line']:
         for key, value in scan_data.items():
             if value is None:
                 continue
@@ -168,6 +174,23 @@ def modify_scan_data(scan_data: dict, scan_type: str):
             if value is None:
                 continue
             data = np.array(value)
+            # if it is column vector, make it a row vector
+            if data.shape[1] == 1:
+                data = data.reshape(-1)
+            # if rows (or elements of a row) are identical, pick the first one
+            if np.all(np.diff(data, axis=0) == 0):
+                data = data[0].reshape(-1)
+            output[key] = data * value[0].units
+        return output
+
+    elif scan_type == 'area_detector':
+        for key, value in scan_data.items():
+            if value is None:
+                continue
+            data = np.array(value)
+            if key == 'intensity':
+                output[key] = data * value[0].units
+                continue
             # if it is column vector, make it a row vector
             if data.shape[1] == 1:
                 data = data.reshape(-1)

--- a/src/fairmat_readers_xrd/utils.py
+++ b/src/fairmat_readers_xrd/utils.py
@@ -146,10 +146,10 @@ def modify_scan_data(scan_data: dict, scan_type: str):
     """
     output = collections.defaultdict(lambda: None)
 
-    if scan_type not in ['line', 'rsm', 'multiline']:
+    if scan_type not in ['line', 'rsm', 'multiline', '2d_mode']:
         raise ValueError(f'Invalid scan type: {scan_type}')
 
-    if scan_type == 'line':
+    if scan_type in ['line', '2d_mode']:
         for key, value in scan_data.items():
             if value is None:
                 continue


### PR DESCRIPTION
- [x] Reader for image data available in `Image0.bin` file
- [x] Integration with `read_rigaku_rasx` reader
- [x] Assign new scan type: `area_detector`
- [ ] Add tests

Changes in the output dict of the readers for the `scan_type='area_detector'`:
- `intensity` key contains a 3D array corresponding to the multiple 2D image scans detected by [HyPix-3000](https://rigaku.com/products/components/detectors/hypix-3000) , where the first dimension has the length of the total number of 2D arrays extracted
- `2Theta` key contains the data from the position axis metadata, rather than the scan data.