### PR TITLE
chore: Add weekly CI schedule for pytest

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
 
 permissions:
   contents: read


### PR DESCRIPTION
To ensure that errors in reading the data are caught early when something changes in the dependencies.